### PR TITLE
56 add Actions/Reaction parameters in the database

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 generator docs {
   provider = "node node_modules/prisma-docs-generator"
-  output = "../docs/prisma"
+  output   = "../docs/prisma"
 }
 
 datasource db {
@@ -46,6 +46,7 @@ model Action {
   createdAt                DateTime                   @default(now())
   Service                  Service                    @relation(fields: [serviceId], references: [id])
   serviceId                String
+  params                   Json?
   UsersHasActionsReactions UsersHasActionsReactions[]
 }
 
@@ -57,6 +58,7 @@ model Reaction {
   createdAt                DateTime                   @default(now())
   Service                  Service                    @relation(fields: [serviceId], references: [id])
   serviceId                String
+  params                   Json?
   UsersHasActionsReactions UsersHasActionsReactions[]
 }
 
@@ -69,13 +71,15 @@ model ActionTrigger {
 }
 
 model UsersHasActionsReactions {
-  id         String   @id @unique @default(cuid())
-  User       User     @relation(fields: [userId], references: [id])
-  Action     Action   @relation(fields: [actionId], references: [id])
-  Reaction   Reaction @relation(fields: [reactionId], references: [id])
-  isEnable   Boolean  @default(true)
-  createdAt  DateTime @default(now())
-  userId     String
-  actionId   String
-  reactionId String
+  id             String   @id @unique @default(cuid())
+  User           User     @relation(fields: [userId], references: [id])
+  Action         Action   @relation(fields: [actionId], references: [id])
+  Reaction       Reaction @relation(fields: [reactionId], references: [id])
+  isEnable       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  userId         String
+  actionId       String
+  actionParams   Json?
+  reactionId     String
+  reactionParams Json?
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -10,6 +10,10 @@ generator docs {
   output   = "../docs/prisma"
 }
 
+generator dbml {
+  provider = "prisma-dbml-generator"
+}
+
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
@@ -24,7 +28,6 @@ model User {
   mailVerification         Boolean                    @default(false)
   confirmProcess           String                     @default("")
   createdAt                DateTime                   @default(now())
-  ActionTriggers           ActionTrigger[]
   UsersHasActionsReactions UsersHasActionsReactions[]
 }
 
@@ -46,7 +49,7 @@ model Action {
   createdAt                DateTime                   @default(now())
   Service                  Service                    @relation(fields: [serviceId], references: [id])
   serviceId                String
-  params                   Json?
+  Parameters               Parameter[]
   UsersHasActionsReactions UsersHasActionsReactions[]
 }
 
@@ -58,28 +61,51 @@ model Reaction {
   createdAt                DateTime                   @default(now())
   Service                  Service                    @relation(fields: [serviceId], references: [id])
   serviceId                String
-  params                   Json?
+  Parameters               Parameter[]
   UsersHasActionsReactions UsersHasActionsReactions[]
 }
 
-model ActionTrigger {
-  id          String   @id @unique @default(cuid())
-  name        String
-  description String?
-  createdAt   DateTime @default(now())
-  Users       User[]
+model Parameter {
+  id                String              @id @unique @default(cuid())
+  name              String
+  displayName       String
+  description       String?
+  action            Action?             @relation(fields: [actionId], references: [id])
+  actionId          String?
+  reaction          Reaction?           @relation(fields: [reactionId], references: [id])
+  reactionId        String?
+  ActionParameters  ActionParameter[]
+  ReactionParameter ReactionParameter[]
+}
+
+model ActionParameter {
+  id                         String                   @id @unique @default(cuid())
+  value                      String
+  parameter                  Parameter                @relation(fields: [parameterId], references: [id])
+  parameterId                String
+  UsersHasActionsReactions   UsersHasActionsReactions @relation(fields: [usersHasActionsReactionsId], references: [id])
+  usersHasActionsReactionsId String
+}
+
+model ReactionParameter {
+  id                         String                   @id @unique @default(cuid())
+  value                      String
+  parameter                  Parameter                @relation(fields: [parameterId], references: [id])
+  parameterId                String
+  UsersHasActionsReactions   UsersHasActionsReactions @relation(fields: [usersHasActionsReactionsId], references: [id])
+  usersHasActionsReactionsId String
 }
 
 model UsersHasActionsReactions {
-  id             String   @id @unique @default(cuid())
-  User           User     @relation(fields: [userId], references: [id])
-  Action         Action   @relation(fields: [actionId], references: [id])
-  Reaction       Reaction @relation(fields: [reactionId], references: [id])
-  isEnable       Boolean  @default(true)
-  createdAt      DateTime @default(now())
-  userId         String
-  actionId       String
-  actionParams   Json?
-  reactionId     String
-  reactionParams Json?
+  id                String              @id @unique @default(cuid())
+  User              User                @relation(fields: [userId], references: [id])
+  Action            Action              @relation(fields: [actionId], references: [id])
+  Reaction          Reaction            @relation(fields: [reactionId], references: [id])
+  isEnable          Boolean             @default(true)
+  createdAt         DateTime            @default(now())
+  userId            String
+  actionId          String
+  reactionId        String
+  ActionParameter   ActionParameter[]
+  ReactionParameter ReactionParameter[]
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -10,10 +10,6 @@ generator docs {
   output   = "../docs/prisma"
 }
 
-generator dbml {
-  provider = "prisma-dbml-generator"
-}
-
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -62,22 +62,22 @@ model Reaction {
 }
 
 model Parameter {
-  id                String              @id @unique @default(cuid())
-  name              String
-  displayName       String
-  description       String?
-  action            Action?             @relation(fields: [actionId], references: [id])
-  actionId          String?
-  reaction          Reaction?           @relation(fields: [reactionId], references: [id])
-  reactionId        String?
-  ActionParameters  ActionParameter[]
-  ReactionParameter ReactionParameter[]
+  id                 String              @id @unique @default(cuid())
+  name               String
+  displayName        String
+  description        String?
+  Action             Action?             @relation(fields: [actionId], references: [id])
+  actionId           String?
+  Reaction           Reaction?           @relation(fields: [reactionId], references: [id])
+  reactionId         String?
+  ActionParameters   ActionParameter[]
+  ReactionParameters ReactionParameter[]
 }
 
 model ActionParameter {
   id                         String                   @id @unique @default(cuid())
   value                      String
-  parameter                  Parameter                @relation(fields: [parameterId], references: [id])
+  Parameter                  Parameter                @relation(fields: [parameterId], references: [id])
   parameterId                String
   UsersHasActionsReactions   UsersHasActionsReactions @relation(fields: [usersHasActionsReactionsId], references: [id])
   usersHasActionsReactionsId String
@@ -86,22 +86,22 @@ model ActionParameter {
 model ReactionParameter {
   id                         String                   @id @unique @default(cuid())
   value                      String
-  parameter                  Parameter                @relation(fields: [parameterId], references: [id])
+  Parameter                  Parameter                @relation(fields: [parameterId], references: [id])
   parameterId                String
   UsersHasActionsReactions   UsersHasActionsReactions @relation(fields: [usersHasActionsReactionsId], references: [id])
   usersHasActionsReactionsId String
 }
 
 model UsersHasActionsReactions {
-  id                String              @id @unique @default(cuid())
-  User              User                @relation(fields: [userId], references: [id])
-  Action            Action              @relation(fields: [actionId], references: [id])
-  Reaction          Reaction            @relation(fields: [reactionId], references: [id])
-  isEnable          Boolean             @default(true)
-  createdAt         DateTime            @default(now())
-  userId            String
-  actionId          String
-  reactionId        String
-  ActionParameter   ActionParameter[]
-  ReactionParameter ReactionParameter[]
+  id                 String              @id @unique @default(cuid())
+  User               User                @relation(fields: [userId], references: [id])
+  Action             Action              @relation(fields: [actionId], references: [id])
+  Reaction           Reaction            @relation(fields: [reactionId], references: [id])
+  isEnable           Boolean             @default(true)
+  createdAt          DateTime            @default(now())
+  userId             String
+  actionId           String
+  reactionId         String
+  ActionParameters   ActionParameter[]
+  ReactionParameters ReactionParameter[]
 }


### PR DESCRIPTION
# Purpose

The purpose of this pull request is to add actions and reaction parameters in the database architecture.
Do not forget to create a migration.

Fixes #56

## Added features

* New tables are available:
* Parameter: This table stores the differents parameters without the value for the Actions and Reactions.
* ActionParameter: This table is used to store the value of the Action's parameters, and this table is used in UserHasActionsReactions model.
* ReactionParameter: This table is used to store the value of the Reaction's parameters, and this table is used in UserHasActionsReactions model.

## Updated features

* UserHasActionsReactions model has now to new relations with ActionParameters and ReactionParamaters. These tables allow to store the parameters used by the actions and reaction for each A/REA wanted by the user.

## Removed features
* The model ActionTriggers does not exist anymore. It was useless because Parameter models are more permissive. 